### PR TITLE
Calendar file name expectation

### DIFF
--- a/lib/gtfs/calendar.rb
+++ b/lib/gtfs/calendar.rb
@@ -7,7 +7,7 @@ module GTFS
 
     collection_name :calendars
     required_file true
-    uses_filename 'calendars.txt'
+    uses_filename 'calendar.txt'
 
     def self.parse_calendars(data)
       return parse_models(data)


### PR DESCRIPTION
The Calendar class was looking for the wrong filename, and was throwing this error upon attempts to access source.calendars:
- GTFS::InvalidSourceException: Missing required source file: calendars.txt

So I un-pluralized the filename expected by the Calendar class to match the [gtfs specs](https://developers.google.com/transit/gtfs/reference#calendar_fields).
