### PR TITLE
Locked rubyzip dependency to < 1.0.0

### DIFF
--- a/gtfs.gemspec
+++ b/gtfs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rake'
   gem.add_dependency 'multi_json'
-  gem.add_dependency 'rubyzip'
+  gem.add_dependency 'rubyzip', '< 1.0.0'
 
   gem.add_development_dependency 'rspec', ['>= 2.0.0']
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
RubyZip implementation changed in v1.0.0
