### PR TITLE
Update temp zip timestamp, remove filename spaces

### DIFF
--- a/lib/gtfs/url_source.rb
+++ b/lib/gtfs/url_source.rb
@@ -6,7 +6,7 @@ module GTFS
 
     def load_archive(source_url)
       Dir.mktmpdir do |tmp|
-        file_name = File.join(tmp, "/gtfs_temp_#{Time.now}.zip")
+        file_name = File.join(tmp, "/gtfs_temp_#{Time.now.strftime('%Y%jT%H%M%S%z')}.zip")
         uri = URI.parse(source_url)
         response = Net::HTTP.get_response(uri)
         open(file_name, 'wb') do |file|


### PR DESCRIPTION
Space in the temporary zip file name is causing some issues on a Ruby 2.0.0-x86 Windows install. This changes the temp filename to remove the spaces from the datetime-stamp.
