### PR TITLE
Either short_name or long_name required

### DIFF
--- a/lib/gtfs/route.rb
+++ b/lib/gtfs/route.rb
@@ -2,8 +2,8 @@ module GTFS
   class Route
     include GTFS::Model
 
-    has_required_attrs :id, :short_name, :long_name, :type
-    has_optional_attrs :agency_id, :desc, :url, :color, :text_color
+    has_required_attrs :id, :type
+    has_optional_attrs :agency_id, :desc, :url, :color, :text_color, :short_name, :long_name
     attr_accessor *attrs
 
     column_prefix :route_
@@ -14,6 +14,10 @@ module GTFS
 
     def self.parse_routes(data, options={})
       return parse_models(data, options)
+    end
+
+    def valid?
+      super && ! (short_name || long_name).nil?
     end
   end
 end

--- a/spec/gtfs/route_spec.rb
+++ b/spec/gtfs/route_spec.rb
@@ -10,5 +10,26 @@ describe GTFS::Route do
     subject {GTFS::Route.parse_routes(source_text, opts)}
 
     include_examples 'models'
+
+    context '#valid' do
+      let(:opts) {{}}
+      let(:source_text) {header_line + valid_line}
+
+      context 'routes with only short name' do
+        let(:valid_line) {"4679,1,001,,,3,,0000FF,FFFFFF\n"}
+
+        it "are valid" do
+          subject.first.valid?.should == true
+        end
+      end
+
+      context 'routes with only long name' do
+        let(:valid_line) {"4679,1,,SINAI - FORT McHENRY,,3,,0000FF,FFFFFF\n"}
+
+        it "are valid" do
+          subject.first.valid?.should == true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Both are not required in the spec and without this change Routes without
both are excluded from the results.

This should fix Issue #24 