### PR TITLE
Update models to latest revision of GTFS spec

### DIFF
--- a/lib/gtfs/agency.rb
+++ b/lib/gtfs/agency.rb
@@ -3,7 +3,7 @@ module GTFS
     include GTFS::Model
 
     has_required_attrs :name, :url, :timezone
-    has_optional_attrs :id, :lang, :phone, :fare_url
+    has_optional_attrs :id, :lang, :phone, :fare_url, :email
     attr_accessor *attrs
 
     column_prefix :agency_

--- a/lib/gtfs/fare_attribute.rb
+++ b/lib/gtfs/fare_attribute.rb
@@ -2,8 +2,8 @@ module GTFS
   class FareAttribute
     include GTFS::Model
 
-    has_required_attrs :fare_id, :price, :currency_type, :payment_method
-    has_optional_attrs :transfer_duration, :transfers
+    has_required_attrs :fare_id, :price, :currency_type, :payment_method, :transfers
+    has_optional_attrs :transfer_duration 
     attr_accessor *attrs
 
     collection_name :fare_attributes

--- a/lib/gtfs/stop_time.rb
+++ b/lib/gtfs/stop_time.rb
@@ -3,7 +3,7 @@ module GTFS
     include GTFS::Model
 
     has_required_attrs :trip_id, :arrival_time, :departure_time, :stop_id, :stop_sequence
-    has_optional_attrs :stop_headsign, :pickup_type, :drop_off_type, :shape_dist_traveled
+    has_optional_attrs :stop_headsign, :pickup_type, :drop_off_type, :shape_dist_traveled, :timepoint
     attr_accessor *attrs
 
     collection_name :stop_times

--- a/lib/gtfs/trip.rb
+++ b/lib/gtfs/trip.rb
@@ -3,7 +3,7 @@ module GTFS
     include GTFS::Model
 
     has_required_attrs :route_id, :service_id, :id
-    has_optional_attrs :headsign, :short_name, :direction_id, :block_id, :shape_id, :wheelchair_accessible
+    has_optional_attrs :headsign, :short_name, :direction_id, :block_id, :shape_id, :wheelchair_accessible, :bikes_allowed
     attr_accessor *attrs
 
     column_prefix :trip_

--- a/spec/gtfs/agency_spec.rb
+++ b/spec/gtfs/agency_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe GTFS::Agency do
   describe 'Agency.parse_agencies' do
-    let(:header_line) {"agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone\n"}
+    let(:header_line) {"agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone,agency_email\n"}
     let(:invalid_header_line) {"agency_id,agency_url,agency_timezone,agency_lang,agency_phone\n"}
     let(:valid_line) {"1,Maryland Transit Administration,http://www.mta.maryland.gov,America/New_York,en,410-539-5000\n"}
     let(:invalid_line) {"1,,http://www.mta.maryland.gov,America/New_York,en,410-539-5000\n"}

--- a/spec/gtfs/stop_time_spec.rb
+++ b/spec/gtfs/stop_time_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe GTFS::StopTime do
   describe 'StopTime.parse_stop_times' do
-    let(:header_line) {"trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_type,drop_off_type,shape_dist_traveled\n"}
+    let(:header_line) {"trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_type,drop_off_type,shape_dist_traveled,timepoint\n"}
     let(:invalid_header_line) {",arrival_time,,stop_id,,stop_headsign,,drop_off_type,\n"}
     let(:valid_line) {"982385,4:34:00,4:34:00,277,1,,0,0,\n"}
     let(:invalid_line) {",,4:34:00,,1,,,0,\n"}

--- a/spec/gtfs/trip_spec.rb
+++ b/spec/gtfs/trip_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe GTFS::Trip do
   describe 'Trip.parse_trips' do
-    let(:header_line) {"route_id,service_id,trip_id,trip_headsign,direction_id,block_id,shape_id\n"}
+    let(:header_line) {"route_id,service_id,trip_id,trip_headsign,direction_id,block_id,shape_id,bikes_allowed\n"}
     let(:invalid_header_line) {",,,,direction_id,block_id,shape_id\n"}
     let(:valid_line) {"4679,1,982394,1 FT McHENRY,0,189021,59135\n"}
     let(:invalid_line) {",1,,1 FT McHENRY,,189021,\n"}


### PR DESCRIPTION
Updated some of the model attributes to be in line with the latest reference of the GTFS spec. Revised February 3, 2016.

https://developers.google.com/transit/gtfs/reference